### PR TITLE
Fix: `get_section_info()` method signature uses only 1 parameter.

### DIFF
--- a/src/SiteHealthCommand.php
+++ b/src/SiteHealthCommand.php
@@ -264,11 +264,11 @@ class SiteHealthCommand extends WP_CLI_Command {
 			$details = [];
 
 			foreach ( $sections as $section ) {
-				$details = array_merge( $details, $this->get_section_info( $section, $assoc_args ) );
+				$details = array_merge( $details, $this->get_section_info( $section ) );
 			}
 		} else {
 			$this->validate_section( $section );
-			$details = $this->get_section_info( $section, $assoc_args );
+			$details = $this->get_section_info( $section );
 		}
 
 		if ( ! $private ) {


### PR DESCRIPTION
## What
Fixes the `get_section_info()` method calls to only use one parameter.

## Why
Method call is provided 2 parameters, but the method signature uses 1 parameters.

https://github.com/ernilambar/site-health-command/blob/c3b9f20378ae0accda2e4ab55249952747311672/src/SiteHealthCommand.php#L310
